### PR TITLE
Add metadata to all pipelines

### DIFF
--- a/pipelines/ban_list_pipeline.py
+++ b/pipelines/ban_list_pipeline.py
@@ -1,3 +1,13 @@
+"""
+title: Ban List Pipeline
+author: unbound
+date: 2024-12-13
+version: 1.0
+license: MIT
+description: A pipeline for filtering out banned words or similar variations.
+requirements: fuzzysearch
+"""
+
 from typing import List, Optional
 from pydantic import BaseModel
 from fuzzysearch import find_near_matches

--- a/pipelines/bias_check_pipeline.py
+++ b/pipelines/bias_check_pipeline.py
@@ -1,3 +1,13 @@
+"""
+title: Bias Check Pipeline
+author: unbound
+date: 2024-12-13
+version: 1.0
+license: MIT
+description: A pipeline for checking if the content is biased.
+requirements: transformers
+"""
+
 from typing import List, Optional
 from pydantic import BaseModel
 from transformers import AutoTokenizer, TFAutoModelForSequenceClassification, pipeline

--- a/pipelines/failed/regex_filter_pipeline.py
+++ b/pipelines/failed/regex_filter_pipeline.py
@@ -1,7 +1,16 @@
+"""
+title: Regex Filter Pipeline
+author: unbound
+date: 2024-12-13
+version: 1.0
+license: MIT
+description: A pipeline for filtering out messages based on regex patterns.
+requirements: re
+"""
+
 from typing import List, Optional
 from pydantic import BaseModel
 import re
-
 
 class Pipeline:
     class Valves(BaseModel):

--- a/pipelines/regex_filter_pipeline.py
+++ b/pipelines/regex_filter_pipeline.py
@@ -5,7 +5,6 @@ date: 2024-12-13
 version: 1.0
 license: MIT
 description: A pipeline for filtering out messages based on regex patterns.
-requirements: re
 """
 
 from typing import List, Optional

--- a/pipelines/restrict_to_topic_pipeline.py
+++ b/pipelines/restrict_to_topic_pipeline.py
@@ -1,7 +1,16 @@
+"""
+title: Restrict to Topic Filter
+author: unbound
+date: 2024-12-13
+version: 1.0
+license: MIT
+description: A pipeline for filtering out messages based on topic.
+requirements: transformers
+"""
+
 from typing import List, Optional
 from pydantic import BaseModel
 from transformers import pipeline
-
 
 class Pipeline:
     class Valves(BaseModel):


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added metadata documentation to pipeline files while revealing inconsistencies in request handling and bias detection implementations.

- Inconsistent request handling in `pipelines/restrict_to_topic_pipeline.py` where inlet method alternates between returning `request.body` and full `request`
- Mismatched bias labels in `pipelines/bias_check_pipeline.py` - inlet checks for "Biased" while outlet checks for "LABEL_1"
- Added standardized metadata format across all pipeline files including title, author, date, version, license, description and requirements
- Correctly specified `fuzzysearch` requirement in `ban_list_pipeline.py` metadata to match imports



<!-- /greptile_comment -->