### PR TITLE
[WEB-1648] Updating ban list pipeline to accept before request

### DIFF
--- a/pipelines/ban_list_pipeline.py
+++ b/pipelines/ban_list_pipeline.py
@@ -49,7 +49,19 @@ class Pipeline:
         if not banned_words:
             return body
 
-        message = body.get("text", "")
+        if 'text' in body:
+            message = body.get("text", "")
+        else:
+            messages = body.get("messages", [])
+
+            # Manually extract the last user message
+            user_message = None
+            for message in reversed(messages):
+                if message.get("role") == "user":
+                    user_message = message
+                    break
+            
+            message = user_message.get("content", "")
 
         if message:
             if not message.strip():

--- a/pipelines/ban_list_pipeline.py
+++ b/pipelines/ban_list_pipeline.py
@@ -57,9 +57,9 @@ class Pipeline:
 
             # Manually extract the last user message
             user_message = None
-            for message in reversed(messages):
-                if message.get("role") == "user":
-                    user_message = message
+            for msg in reversed(messages):
+                if msg.get("role") == "user":
+                    user_message = msg
                     break
             
             if user_message:

--- a/pipelines/ban_list_pipeline.py
+++ b/pipelines/ban_list_pipeline.py
@@ -48,10 +48,11 @@ class Pipeline:
         banned_words = config.get("ban_list", [])
         if not banned_words:
             return body
-
+        
+        message = None
         if 'text' in body:
             message = body.get("text", "")
-        else:
+        elif 'messages' in body:
             messages = body.get("messages", [])
 
             # Manually extract the last user message
@@ -61,7 +62,8 @@ class Pipeline:
                     user_message = message
                     break
             
-            message = user_message.get("content", "")
+            if user_message:
+                message = user_message.get("content", "")
 
         if message:
             if not message.strip():


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Enhanced the ban list pipeline's inlet method to support multiple message format types, improving compatibility for text filtering across different input structures.

- Modified `/pipelines/ban_list_pipeline.py` to handle both direct 'text' field and 'messages' array inputs
- Fixed variable shadowing by renaming loop variable from 'message' to 'msg'
- Added initialization of message variable to None for better error handling
- Missing validation for empty/invalid user messages could allow banned content to pass silently



<!-- /greptile_comment -->