### PR TITLE
Adds numpy, tokenizers to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ RUN if [ "$MINIMUM_BUILD" != "true" ]; then \
             pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \    
         fi \
     fi
-# Add explicit installation of transformers
-RUN pip3 install --no-cache-dir transformers
+# Remove the explicit transformers installation
 RUN if [ "$MINIMUM_BUILD" = "true" ]; then \
         uv pip install --system -r requirements-minimum.txt --no-cache-dir; \
     else \

--- a/requirements-minimum.txt
+++ b/requirements-minimum.txt
@@ -13,9 +13,9 @@ requests==2.32.2
 aiohttp==3.9.5
 httpx
 
-transformers
-numpy
-tokenizers
-torch>=1.7.0
+numpy==2.2.3             
+torch==2.6.0      
+transformers==5.0.0
+tokenizers==0.20.0
 
 

--- a/requirements-minimum.txt
+++ b/requirements-minimum.txt
@@ -14,4 +14,7 @@ aiohttp==3.9.5
 httpx
 
 transformers
+numpy
+tokenizers
+torch>=1.7.0
 

--- a/requirements-minimum.txt
+++ b/requirements-minimum.txt
@@ -13,3 +13,5 @@ requests==2.32.2
 aiohttp==3.9.5
 httpx
 
+transformers
+


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added version constraints for key ML dependencies in requirements-minimum.txt to ensure consistent builds and resolve import errors.

- Added `numpy==2.2.3` in `/requirements-minimum.txt` - note this is a very recent version that may have compatibility issues
- Added `torch==2.6.0` in `/requirements-minimum.txt` which is a stable version
- Added `transformers==5.0.0` and `tokenizers==0.20.0` in `/requirements-minimum.txt` for consistent transformer library support
- Consider downgrading numpy to a more widely-supported version like 1.24.x for better compatibility



<!-- /greptile_comment -->