### PR TITLE
[WEB-1946] Fixes dockerfile to install all dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,15 @@ COPY . .
 ENV HOST="0.0.0.0"
 ENV PORT="8080"
 
+# Install the missing OpenCV dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libgl1-mesa-glx \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "bash", "start.sh" ]


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR modifies the Dockerfile to include necessary OpenCV system dependencies required for the opencv-python package functionality.

- Added OpenCV system dependencies in `/Dockerfile` using apt-get with --no-install-recommends flag
- Consider moving dependency installation earlier in Dockerfile for better layer caching
- Proper cleanup of apt cache is performed to minimize image size

The changes are straightforward but could be optimized for better Docker build performance through layer ordering.



<!-- /greptile_comment -->