### PR TITLE
chore(k8s): hold off pipelines in dev (replicaCount=0)

### DIFF
--- a/k8s/dev/values.yaml
+++ b/k8s/dev/values.yaml
@@ -6,6 +6,10 @@
 # service.port 8080, ingress disabled, resources sized for ML workload).
 # Overlay carries only what differs from base.
 
+# Held off in dev until health stabilises — service not required to be
+# operational yet. Flip back to 1 (or remove this line) to bring it up.
+replicaCount: 0
+
 image:
   repository: 228304386839.dkr.ecr.us-west-2.amazonaws.com/k8s/pipelines
 


### PR DESCRIPTION
## Summary
- Set `replicaCount: 0` in `k8s/dev/values.yaml` so the dev Deployment scales to zero.
- Pipelines is not required to be operational in dev right now and recent rollouts have been failing health checks — scaling to zero keeps ArgoCD reconciling cleanly without churning unhealthy pods.
- HPA is disabled in the base chart (and not enabled by the dev overlay), so `replicaCount: 0` is not overridden.

To bring the service back: set `replicaCount: 1` (or remove the override) and resync the ArgoCD app.

## Test plan
- [x] `helm lint k8s/chart -f k8s/dev/values.yaml` clean
- [ ] After merge, confirm ArgoCD `pipelines` app reports Healthy with 0/0 pods

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Sets `replicaCount: 0` in the dev Helm overlay to scale the pipelines Deployment to zero while health checks are stabilising in dev. No code, schema, or API changes are included.

- Adds a single `replicaCount: 0` line to `k8s/dev/values.yaml` with an inline comment explaining the hold-off and how to reverse it.
- The dev-only overlay means prod and staging are unaffected; the base chart's HPA is not enabled for dev, so the zero replica count is not overridden at runtime.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line Helm overlay change affecting only the dev environment with no impact on production or staging.

The change touches one value in a dev-only Helm overlay. It scales the dev Deployment to zero, which is intentional and documented. Prod and staging are unaffected. The comment in the file and the PR description both explain the rationale and how to reverse it.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| k8s/dev/values.yaml | Adds `replicaCount: 0` to scale the dev deployment to zero; change is minimal, well-commented, and scoped only to the dev overlay. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ArgoCD reconcile loop] --> B{replicaCount in dev overlay}
    B -- "0 (current)" --> C[Deployment scaled to 0 pods]
    C --> D[ArgoCD reports Healthy — no pods churning]
    B -- "1 (to restore)" --> E[Deployment scaled to 1 pod]
    E --> F[Readiness probe passes?]
    F -- Yes --> G[Pod Running / ArgoCD Healthy]
    F -- No --> H[Pod fails health check / ArgoCD Degraded]
```

<sub>Reviews (1): Last reviewed commit: ["chore(k8s): hold off pipelines in dev (r..."](https://github.com/websentry-ai/pipelines/commit/f33fac235348b09e1ffe2529e76fe45af9ab491d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36565820)</sub>

<!-- /greptile_comment -->