### PR TITLE
fix(prod): raise pipelines memory request 1Gi→3Gi (stop eviction loop)

### DIFF
--- a/k8s/prod/values.yaml
+++ b/k8s/prod/values.yaml
@@ -30,3 +30,16 @@ env:
     value: "0.0.0.0"
   - name: PIPELINES_DIR
     value: "./pipelines"
+
+# Memory raised 1Gi -> 3Gi (limit kept 4Gi). pipelines-prod uses ~1978Mi = 193%
+# of the old 1Gi request, so under node memory pressure the kubelet evicted it
+# repeatedly (27 evicted zombie pods piled up), and its memory-based HPA read
+# ~193%/75% and stayed pinned at max. 3Gi request stops the evictions and lets
+# the HPA scale on real load. CPU unchanged (500m/2 from the chart default).
+resources:
+  requests:
+    cpu: "500m"
+    memory: "3Gi"
+  limits:
+    cpu: "2"
+    memory: "4Gi"


### PR DESCRIPTION
## What
`pipelines-prod` mem request `1Gi → 3Gi` (limit kept `4Gi`), prod-only override.

## Why
pipelines uses **~1978Mi = 193% of its 1Gi request**. As Burstable QoS exceeding its request, the kubelet evicts it first under node memory pressure — repeatedly → **27 evicted zombie pods** piled up + `KubePodNotReady` alert noise, and its memory-based HPA read ~193%/75% so it stayed **pinned at maxReplicas**. 3Gi request stops the evictions and lets the HPA scale on real load. Verified with `helm template` (renders `memory: 3Gi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prod Helm resource tuning with documented rationale; no app code or security surface changes, though it increases guaranteed memory per pod on nodes.
> 
> **Overview**
> **Prod-only** override in `k8s/prod/values.yaml` sets explicit `resources` for `pipelines-prod`: memory **request** goes from the chart default **1Gi** to **3Gi**, while **limits stay 4Gi CPU/2** (same as before).
> 
> This targets a Burstable pod running ~**1978Mi** (~193% of the old request), which was getting **kubelet-evicted** under node memory pressure (many evicted pods, `KubePodNotReady` noise) and kept the **memory HPA** saturated at **maxReplicas** (~193%/75%). Raising the request should reduce evictions and let autoscaling reflect real load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f6ef64280f966edb31599c7d217ad3c74c75c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the prod memory request for the pipelines deployment.

- Adds a prod-only `resources` override in `k8s/prod/values.yaml`.
- Changes the memory request from `1Gi` to `3Gi`.
- Keeps the existing CPU request, CPU limit, and memory limit values.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| k8s/prod/values.yaml | Adds a prod-specific resources override that matches the chart's existing container resources shape. |

<sub>Reviews (1): Last reviewed commit: ["fix(prod): raise pipelines memory reques..."](https://github.com/websentry-ai/pipelines/commit/31f6ef64280f966edb31599c7d217ad3c74c75c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44046527)</sub>

**Context used:**

- Rule used - Ensure that the confidence score is always within ... ([source](https://app.greptile.com/unboundsecurity-org-2/-/custom-context?memory=783fec3c-d2a2-473f-aa5a-0a58f385e66b))

**Learned From**
[websentry-ai/ai-gateway-data#448](https://github.com/websentry-ai/ai-gateway-data/pull/448)

<!-- /greptile_comment -->