### PR TITLE
fix(prod): raise pipelines cpu request 500m→900m

### DIFF
--- a/k8s/prod/values.yaml
+++ b/k8s/prod/values.yaml
@@ -38,7 +38,7 @@ env:
 # the HPA scale on real load. CPU unchanged (500m/2 from the chart default).
 resources:
   requests:
-    cpu: "500m"
+    cpu: "900m"
     memory: "3Gi"
   limits:
     cpu: "2"


### PR DESCRIPTION
cpu p95 865m = 173% of the old 500m request. Completes the pipelines right-size (memory was #32). Limit kept at 2 cores for bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single production Helm values tweak for resource requests on an in-cluster private service; no app logic or exposure changes.
> 
> **Overview**
> Raises the **prod pipelines** Deployment CPU **request** from `500m` to `900m` in `k8s/prod/values.yaml`, matching observed **p95 ~865m** (~173% of the old request). This follows the earlier memory right-size and aligns scheduling/HPA utilization with actual load.
> 
> CPU **limit** stays at `2` for burst headroom; memory requests/limits are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1077f793e9a0b2cf0f1bc8cc14c178ef0fb107d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the production CPU request for the pipelines workload.

- Updates `k8s/prod/values.yaml` from `500m` to `900m`.
- Keeps the CPU limit at `2` cores.
- Leaves the memory request and limit unchanged.

<h3>Confidence Score: 5/5</h3>

The change looks mergeable after a small cleanup to the resource comment.

- The Kubernetes value is a valid CPU request.
- The chart passes the resources block through directly.
- The only issue found is stale text next to the updated value.

k8s/prod/values.yaml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| k8s/prod/values.yaml | Raises the production CPU request to `900m`; the nearby comment still describes the old `500m` default. |

<sub>Reviews (1): Last reviewed commit: ["fix(prod): raise pipelines cpu request 5..."](https://github.com/websentry-ai/pipelines/commit/1077f793e9a0b2cf0f1bc8cc14c178ef0fb107d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44069954)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Ensure that the confidence score is always within ... ([source](https://app.greptile.com/unboundsecurity-org-2/-/custom-context?memory=783fec3c-d2a2-473f-aa5a-0a58f385e66b))

**Learned From**
[websentry-ai/ai-gateway-data#448](https://github.com/websentry-ai/ai-gateway-data/pull/448)

<!-- /greptile_comment -->