### PR TITLE
chore(prod): sleep pipelines-prod (scale to 0)

### DIFF
--- a/k8s/prod/values.yaml
+++ b/k8s/prod/values.yaml
@@ -17,8 +17,16 @@ externalSecret:
 ingress:
   enabled: false
 
+# SLEPT 2026-07 — pipelines has no live entrypoint (the FE flow that adds filter
+# cases for NSFW/hate-speech/etc. is disabled, so enabled_filters is always empty
+# and the service is never meaningfully invoked). Scaled to 0 to save cost. Its
+# in-cluster callers (ai-gateway, gateway-data web+celery) are being disabled in
+# parallel — UNBOUND_PIPELINES_URL removed from their env so they skip the call
+# cleanly (no fail-open timeout). To WAKE: set replicaCount back to 1 (or
+# autoscaling.enabled: true) AND restore UNBOUND_PIPELINES_URL in the consumers.
+replicaCount: 0
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 2
 


### PR DESCRIPTION
Scale pipelines-prod to 0 (no live entrypoint — FE filter-case flow disabled). Cost saving, reversible (replicaCount 1 / autoscaling.enabled true).

**Merge order:** AFTER the consumer-disable PRs (ai-gateway + ai-gateway-data) so nothing fail-open-timeouts against a sleeping service. **Wake before any DNS flip brings real traffic.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables a production backend that ai-gateway still could call if merged before consumer env changes, causing fail-open timeouts; otherwise low impact while filters are unused.
> 
> **Overview**
> **Puts `pipelines-prod` to sleep** in prod by setting **`replicaCount: 0`** and turning **`autoscaling.enabled`** off, so the private filter plugin service runs no pods and stops incurring compute cost.
> 
> The overlay adds a **SLEPT 2026-07** comment explaining that the FE filter-case flow is disabled (filters are always empty), that **ai-gateway** and **ai-gateway-data** should drop **`UNBOUND_PIPELINES_URL`** in parallel so callers skip pipelines instead of timing out, and how to **wake** the service (restore replicas/autoscaling and the env URL on consumers). **Merge after** those consumer PRs; wake pipelines before any DNS flip that sends real traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594fe50c6605517a6703b37792166ec094b33006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR sleeps the production pipelines deployment. The main changes are:

- Sets `pipelines-prod` replicas to zero.
- Disables autoscaling for the production deployment.
- Adds notes for the consumer-disable and manual wake-up steps.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after the consumer-disable rollout has completed.

- The changed service is private and has no ingress.
- The remaining risk is rollout ordering: old consumer pods can still call the sleeping ClusterIP until they restart without the URL.
- The wake-up path is manual and documented in the changed values file.

k8s/prod/values.yaml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| k8s/prod/values.yaml | Changes production Helm values to run zero replicas with no autoscaler, with comments documenting the required consumer and wake-up steps. |

<sub>Reviews (1): Last reviewed commit: ["chore(prod): sleep pipelines-prod (scale..."](https://github.com/websentry-ai/pipelines/commit/594fe50c6605517a6703b37792166ec094b33006) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45073973)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Ensure that the confidence score is always within ... ([source](https://app.greptile.com/unboundsecurity-org-2/-/custom-context?memory=783fec3c-d2a2-473f-aa5a-0a58f385e66b))

**Learned From**
[websentry-ai/ai-gateway-data#448](https://github.com/websentry-ai/ai-gateway-data/pull/448)

<!-- /greptile_comment -->